### PR TITLE
Add Dockerfile for automated build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:8
+
+ENV JHIPSTER_SLEEP 0
+
+# add source
+ADD . /code/
+# package the application and delete all lib
+RUN echo '{ "allow_root": true }' > /root/.bowerrc && \
+    cd /code/ && \
+    ./mvnw clean package -Pprod -DskipTests && \
+    mv /code/target/*.war /app.war && \
+    rm -Rf /code /root/.npm/ /tmp && \
+    rm -Rf /root/.m2/
+
+RUN sh -c 'touch /app.war'
+VOLUME /tmp
+EXPOSE 8080
+CMD echo "The application will start in ${JHIPSTER_SLEEP}s..." && \
+    sleep ${JHIPSTER_SLEEP} && \
+    java -Djava.security.egd=file:/dev/./urandom -jar /app.war


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/4119

The Docker Hub project is already configured: https://hub.docker.com/r/jhipster/jhipster-sample-app-mongodb/

Before merging this, can you:
- Go to settings > Webhooks & services
- Verify the services: Docker => edit
- Click [x] active
- Click on update service
- Then, accept PR (if you're ok :-)
- Back to Services, Docker must be: :white_check_mark: Docker

Thanks in advance!
